### PR TITLE
Work around status management

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ This integration allows you to connect a Behringer Digital Mixer to Home Assista
 - XR16
 - XR18
 
-*Testing has been mostly on the X32*
+*Testing has been mostly on the X32, but has been physically tested agains X32 and XR18*
 
 For each mixer configured by this integration entities for the following are provided.:
 
-For each Channel, Bus, DCA, Matrix, and Main Faders
+For each Channel, Bus, DCA, Matrix, AuxIn and Main Faders
  - Name (Read only)
  - Mute (SWITCH) (Read/Write)
  - Fader (NUMBER) (Read/Write)
@@ -27,6 +27,7 @@ For each Channel, Bus, DCA, Matrix, and Main Faders
 
 In addition to these 'fader' related variables, also provided is
  - Current scene/snapshot number/index (Read/Write)
+ - Firmware (Read only)
 
 ## Data Updates
 The data for the mixer is updated in real time, so each time a button is pressed or fader is moved on the mixer, this is updated in Home Assistant immediately.
@@ -57,6 +58,10 @@ The data for the mixer is updated in real time, so each time a button is pressed
 ## Configuration is done in the UI
 
 <!---->
+- You are asked for the ip address/hostname
+- You are asked for the type of mixer (choose from the list)
+- You are asked for the name of the mixer
+
 
 ## Caveats
 Connection to the mixer is performed via ip address using UDP. If the IP address for the mixer changes, you will need to edit the integration setup. To avoid this, set up a DHCP reservation on your router for your mixer so that it always has the same IP address.

--- a/custom_components/ha_behringer_mixer/api.py
+++ b/custom_components/ha_behringer_mixer/api.py
@@ -64,7 +64,7 @@ class BehringerMixerApiClient:
         return self._get_data()
 
     def _get_data(self) -> any:
-        """Internal function to get data from the API."""
+        """Process the internal data from the API."""
         data = self._mixer.state()
         data["/firmware"] = self._mixer.firmware()
         data["/available"] = self._mixer.subscription_connected()

--- a/custom_components/ha_behringer_mixer/api.py
+++ b/custom_components/ha_behringer_mixer/api.py
@@ -29,7 +29,7 @@ class BehringerMixerApiClient:
         self.tasks = set()
         self.coordinator = None
 
-    async def setup(self):
+    async def setup(self, setup_callbacks=True):
         """Set up everything necessary."""
         self._mixer = mixer_api.create(
             self._mixer_type, ip=self._mixer_ip, logLevel=logging.WARNING, delay=0.002
@@ -37,19 +37,37 @@ class BehringerMixerApiClient:
         await self._mixer.start()
         # Get Initial state first
         await self._mixer.reload()
-        # Setup subscription for live updates
-        task = asyncio.create_task(self._mixer.subscribe(self.new_data_callback))
-        self.tasks.add(task)
-        task.add_done_callback(self.tasks.discard)
+        if setup_callbacks:
+            # Setup subscription for live updates
+            task = asyncio.create_task(self._mixer.subscribe(self.new_data_callback))
+            self.tasks.add(task)
+            task.add_done_callback(self.tasks.discard)
+            task_sub_status = asyncio.create_task(
+                self._mixer.subscription_status_register(
+                    self.subscription_status_callback
+                )
+            )
+            self.tasks.add(task_sub_status)
+            task_sub_status.add_done_callback(self.tasks.discard)
         return True
 
     def mixer_info(self):
         """Return the mixer info."""
         return self._mixer.info()
 
+    def mixer_network_name(self):
+        """Return the mixer network_name."""
+        return self._mixer.name()
+
     async def async_get_data(self) -> any:
+        return self._get_data()
+
+    def _get_data(self) -> any:
         """Get data from the API."""
-        return self._mixer.state()
+        data = self._mixer.state()
+        data["/firmware"] = self._mixer.firmware()
+        data["/available"] = self._mixer.subscription_connected()
+        return data
 
     async def async_set_value(self, address: str, value: str) -> any:
         """Set a specific value on the mixer."""
@@ -62,14 +80,21 @@ class BehringerMixerApiClient:
     def new_data_callback(self, data: dict):  # pylint: disable=unused-argument
         """Handle the callback indicating new data has been received."""
         if self.coordinator:
-            self.coordinator.async_update_listeners()
+            self.coordinator.async_set_updated_data(self._get_data())
+        return True
+
+    def subscription_status_callback(self, subscription_connection):
+        """Handle the callback indicating the status of the subscription connection."""
+        if self.coordinator:
+            self.coordinator.sub_connected = subscription_connection
+        self.new_data_callback({})
         return True
 
     def register_coordinator(self, coordinator):
         """Register the coordinator object."""
         self.coordinator = coordinator
 
-    def stop(self):
+    async def stop(self):
         """Shutdown the client."""
-        self._mixer.unsubscribe()
-        self._mixer.stop()
+        await self._mixer.unsubscribe()
+        await self._mixer.stop()

--- a/custom_components/ha_behringer_mixer/api.py
+++ b/custom_components/ha_behringer_mixer/api.py
@@ -60,10 +60,11 @@ class BehringerMixerApiClient:
         return self._mixer.name()
 
     async def async_get_data(self) -> any:
+        """Get data from the API."""
         return self._get_data()
 
     def _get_data(self) -> any:
-        """Get data from the API."""
+        """Internal function to get data from the API."""
         data = self._mixer.state()
         data["/firmware"] = self._mixer.firmware()
         data["/available"] = self._mixer.subscription_connected()

--- a/custom_components/ha_behringer_mixer/coordinator.py
+++ b/custom_components/ha_behringer_mixer/coordinator.py
@@ -35,6 +35,8 @@ class MixerDataUpdateCoordinator(DataUpdateCoordinator):
             logger=LOGGER,
             name=DOMAIN,
         )
+        self.sub_connected = False
+        self.entity_base_id = self.config_entry.data["NAME"]
         self.entity_catalog = self.build_entity_catalog(self.client.mixer_info())
 
     async def _async_update_data(self):
@@ -48,7 +50,7 @@ class MixerDataUpdateCoordinator(DataUpdateCoordinator):
 
     def build_entity_catalog(self, mixer_info):
         """Build a list of entities."""
-        types = ["channel", "bus", "dca", "matrix"]
+        types = ["channel", "bus", "dca", "matrix", "auxin"]
         entities = {
             "SENSOR": [],
             "NUMBER": [],
@@ -63,9 +65,17 @@ class MixerDataUpdateCoordinator(DataUpdateCoordinator):
         entities["NUMBER"].append(
             {
                 "type": "scene",
-                "key": f"{self.config_entry.entry_id}_scene_current",
+                "key": f"{self.entity_base_id}_scene_current",
                 "default_name": "Current Scene",
                 "base_address": "/scene/current",
+            }
+        )
+        entities["SENSOR"].append(
+            {
+                "type": "generic",
+                "key": f"{self.entity_base_id}_firmware",
+                "default_name": "Firmware Version",
+                "base_address": "/firmware",
             }
         )
         return entities
@@ -82,7 +92,7 @@ class MixerDataUpdateCoordinator(DataUpdateCoordinator):
         entities["SWITCH"].append(
             {
                 "type": "on",
-                "key": f"{self.config_entry.entry_id}_{entity_part}_on",
+                "key": f"{self.entity_base_id}_{entity_part}_on",
                 "default_name": default_name,
                 "name_suffix": "On",
                 "base_address": base_address,
@@ -91,7 +101,7 @@ class MixerDataUpdateCoordinator(DataUpdateCoordinator):
         entities["NUMBER"].append(
             {
                 "type": "fader",
-                "key": f"{self.config_entry.entry_id}_{entity_part}_fader",
+                "key": f"{self.entity_base_id}_{entity_part}_fader",
                 "default_name": default_name,
                 "name_suffix": "Fader",
                 "base_address": base_address,
@@ -100,7 +110,7 @@ class MixerDataUpdateCoordinator(DataUpdateCoordinator):
         entities["SENSOR"].append(
             {
                 "type": "faderdb",
-                "key": f"{self.config_entry.entry_id}_{entity_part}_fader_db",
+                "key": f"{self.entity_base_id}_{entity_part}_fader_db",
                 "default_name": default_name,
                 "name_suffix": "Fader (dB)",
                 "base_address": base_address,

--- a/custom_components/ha_behringer_mixer/entity.py
+++ b/custom_components/ha_behringer_mixer/entity.py
@@ -48,3 +48,8 @@ class BehringerMixerEntity(CoordinatorEntity):
             + " "
             + self.name_suffix
         )
+
+    @property
+    def available(self) -> bool:
+        """Return True if the mixer is available."""
+        return self.coordinator.sub_connected

--- a/custom_components/ha_behringer_mixer/manifest.json
+++ b/custom_components/ha_behringer_mixer/manifest.json
@@ -8,7 +8,7 @@
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/wrodie/ha_behringer_mixer/issues",
     "requirements": [
-      "behringer-mixer==0.4.0"
+      "behringer-mixer==0.4.1"
     ],
     "version": "0.1.1"
 }

--- a/custom_components/ha_behringer_mixer/manifest.json
+++ b/custom_components/ha_behringer_mixer/manifest.json
@@ -1,16 +1,14 @@
 {
-  "domain": "ha_behringer_mixer",
-  "name": "Behringer Mixer",
-  "codeowners": [
-    "@wrodie"
-  ],
-  "config_flow": true,
-  "documentation": "https://github.com/wrodie/ha_behringer_mixer",
-  "integration_type": "device",
-  "iot_class": "local_push",
-  "issue_tracker": "https://github.com/wrodie/ha_behringer_mixer/issues",
-  "requirements": [
-    "behringer-mixer"
-  ],
-  "version": "0.1.1"
+    "domain": "ha_behringer_mixer",
+    "name": "Behringer Mixer",
+    "codeowners": ["@wrodie"],
+    "config_flow": true,
+    "documentation": "https://github.com/wrodie/ha_behringer_mixer",
+    "integration_type": "device",
+    "iot_class": "local_push",
+    "issue_tracker": "https://github.com/wrodie/ha_behringer_mixer/issues",
+    "requirements": [
+      "behringer-mixer==0.4.0"
+    ],
+    "version": "0.1.1"
 }

--- a/custom_components/ha_behringer_mixer/number.py
+++ b/custom_components/ha_behringer_mixer/number.py
@@ -16,16 +16,6 @@ async def async_setup_entry(hass, entry, async_add_devices):
     devices_list = build_entities(coordinator)
     async_add_devices(devices_list)
 
-    # Register service to change scenes
-    # platform = entity_platform.async_get_current_platform()
-    # platform.async_register_entity_sAAervice(
-    #    "SERVICE_CHANGE_SCENE",
-    #    {
-    #        vol.Required("scene_number"): cv.Number,
-    #    },
-    #    "change_scene",
-    # )
-
 
 def build_entities(coordinator):
     """Build up the entities."""

--- a/custom_components/ha_behringer_mixer/sensor.py
+++ b/custom_components/ha_behringer_mixer/sensor.py
@@ -18,20 +18,45 @@ def build_entities(coordinator):
     """Build up the entities."""
     entities = []
     for entity in coordinator.entity_catalog.get("SENSOR"):
-        entities.append(
-            BehringerMixerSensor(
-                coordinator=coordinator,
-                entity_description=SensorEntityDescription(
-                    key=entity.get("key"),
-                    name=entity.get("default_name"),
-                ),
-                entity_setup=entity,
+        if entity.get("type") == "faderdb":
+            entities.append(
+                BehringerMixerDbSensor(
+                    coordinator=coordinator,
+                    entity_description=SensorEntityDescription(
+                        key=entity.get("key"),
+                        name=entity.get("default_name"),
+                    ),
+                    entity_setup=entity,
+                )
             )
-        )
+        else:
+            entities.append(
+                BehringerMixerGenericSensor(
+                    coordinator=coordinator,
+                    entity_description=SensorEntityDescription(
+                        key=entity.get("key"), name=entity.get("default_name")
+                    ),
+                    entity_setup=entity,
+                )
+            )
     return entities
 
 
-class BehringerMixerSensor(BehringerMixerEntity, SensorEntity):
+class BehringerMixerGenericSensor(BehringerMixerEntity, SensorEntity):
+    """Behringer_mixer Generic Sensor class."""
+
+    @property
+    def name(self) -> str | None:
+        """Name  of the entity."""
+        return self.default_name
+
+    @property
+    def native_value(self) -> float | None:
+        """Value of the entity."""
+        return self.coordinator.data.get(self.base_address, "")
+
+
+class BehringerMixerDbSensor(BehringerMixerEntity, SensorEntity):
     """Behringer_mixer Sensor class."""
 
     _attr_device_class = "SensorDeviceClass.SOUND_PRESSURE"

--- a/custom_components/ha_behringer_mixer/translations/en.json
+++ b/custom_components/ha_behringer_mixer/translations/en.json
@@ -7,6 +7,12 @@
                     "MIXER_IP": "Mixer IP Address",
                     "MIXER_TYPE": "Mixer Type eg X32, XR12"
                 }
+            },
+            "name": {
+                "description": "What do you want to call this mixer?",
+                "data": {
+                    "NAME": "Mixer Name"
+                }
             }
         },
         "error": {


### PR DESCRIPTION
Lots of work to better understand when the mixer is available or not Mixer should not update availability properly
Data updates should be slightly better, caterng for some of the edge cases.

Added in new sensor for firmware version.
Potentially breaking change where the name of the entity can now be set properly on setup, it defaults to the network name of the mixer but then gives the user the chance to change it.  This better to use than the random UUID that was initially setup.