### PR TITLE
Configure options and channel,bus sends

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,24 @@
 
 [![hacs][hacsbadge]][hacs]
 
-
 This integration allows you to connect a Behringer Digital Mixer to Home Assistant.
 
-**Mixers Supported**
+For each mixer configured by this integration entities for the following are provided.:
+
+For each Channel, Bus, DCA, Matrix, AuxIn, Main Faders, Channel->Bus sends and Bus->Matrix sends.
+
+- Name (Read-only)
+- Mute (SWITCH) (Read/Write)
+- Fader (NUMBER) (Read/Write)
+- Fader Value - dB (SENSOR) (Read-only)
+
+In addition to these 'fader' related variables, also provided is
+
+- Current scene/snapshot number/index (Read/Write)
+- Firmware (Read only)
+
+## Mixers Supported
+
 - X32
 - XR12
 - XR16
@@ -17,26 +31,13 @@ This integration allows you to connect a Behringer Digital Mixer to Home Assista
 
 *Testing has been mostly on the X32, but has been physically tested agains X32 and XR18*
 
-For each mixer configured by this integration entities for the following are provided.:
-
-For each Channel, Bus, DCA, Matrix, AuxIn and Main Faders
- - Name (Read only)
- - Mute (SWITCH) (Read/Write)
- - Fader (NUMBER) (Read/Write)
- - Fader Value - dB (SENSOR) (Read only)
-
-In addition to these 'fader' related variables, also provided is
- - Current scene/snapshot number/index (Read/Write)
- - Firmware (Read only)
-
 ## Data Updates
+
 The data for the mixer is updated in real time, so each time a button is pressed or fader is moved on the mixer, this is updated in Home Assistant immediately.
-
-
 
 ## Installation
 
-**HACS installation (recommended)**
+### HACS installation (recommended)
 
 1. Install HACS. That way you get updates automatically.
 1. Add this Github repository as custom repository in HACS settings.
@@ -44,40 +45,34 @@ The data for the mixer is updated in real time, so each time a button is pressed
 1. Restart Home Assistant,
 1. Then you can add a Behringer Mixer integration in the integration page.
 
-**Manual installation**
+### Manual installation
 
 1. Using the tool of choice open the directory (folder) for your HA configuration (where you find `configuration.yaml`).
 1. If you do not have a `custom_components` directory (folder) there, you need to create it.
 1. In the `custom_components` directory (folder) create a new folder called `ha_berhringer_mixer`.
-1. Download _all_ the files from the `custom_components/ha_berhringer_mixer/` directory (folder) in this repository.
+1. Download *all* the files from the `custom_components/ha_berhringer_mixer/` directory (folder) in this repository.
 1. Place the files you downloaded in the new directory (folder) you created.
 1. Restart Home Assistant
 1. In the HA UI go to "Configuration" -> "Integrations" click "+" and search for "Behringer Mixer"
 
-
 ## Configuration is done in the UI
 
-<!---->
 - You are asked for the ip address/hostname
 - You are asked for the type of mixer (choose from the list)
 - You are asked for the name of the mixer
 - You can choose which channels/busses/dcas etc to actually import (If you import everything there can be a lot)
 
-
 ## Caveats
+
 Connection to the mixer is performed via ip address using UDP. If the IP address for the mixer changes, you will need to edit the integration setup. To avoid this, set up a DHCP reservation on your router for your mixer so that it always has the same IP address.
 
 This information on changes to the mixer is written to the HA history/recorder databases so this may result in lots of state being stored if the mixer changes a lot.  You may want to consider excluding these entities from storing history.
 
-
-
-
-## Contributions are welcome!
+## Contributions are welcome
 
 If you want to contribute to this please read the [Contribution guidelines](CONTRIBUTING.md)
 
 ***
-
 
 [commits-shield]: https://img.shields.io/github/commit-activity/y/wrodie/ha_behringer_mixer.svg?style=for-the-badge
 [commits]: https://github.com/wrodie/ha_behringer_mixer/commits/main

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The data for the mixer is updated in real time, so each time a button is pressed
 - You are asked for the ip address/hostname
 - You are asked for the type of mixer (choose from the list)
 - You are asked for the name of the mixer
+- You can choose which channels/busses/dcas etc to actually import (If you import everything there can be a lot)
 
 
 ## Caveats

--- a/custom_components/ha_behringer_mixer/api.py
+++ b/custom_components/ha_behringer_mixer/api.py
@@ -4,7 +4,6 @@ import logging
 import asyncio
 from behringer_mixer import mixer_api
 
-
 class BehringerMixerApiClientError(Exception):
     """Exception to indicate a general API error."""
 
@@ -29,15 +28,15 @@ class BehringerMixerApiClient:
         self.tasks = set()
         self.coordinator = None
 
-    async def setup(self, setup_callbacks=True):
+    async def setup(self, test_connection_only=False):
         """Set up everything necessary."""
         self._mixer = mixer_api.create(
             self._mixer_type, ip=self._mixer_ip, logLevel=logging.WARNING, delay=0.002
         )
         await self._mixer.start()
-        # Get Initial state first
-        await self._mixer.reload()
-        if setup_callbacks:
+        if not test_connection_only:
+            # Get Initial state first
+            await self._mixer.reload()
             # Setup subscription for live updates
             task = asyncio.create_task(self._mixer.subscribe(self.new_data_callback))
             self.tasks.add(task)

--- a/custom_components/ha_behringer_mixer/config_flow.py
+++ b/custom_components/ha_behringer_mixer/config_flow.py
@@ -64,7 +64,8 @@ class BehringerMixerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     def create_list(max_number):
-        return [item for item in range(1, max_number + 1)]
+        """ Create a list of numbers """
+        return list(range(1, max_number + 1))
 
     async def async_step_name(
         self,

--- a/custom_components/ha_behringer_mixer/config_flow.py
+++ b/custom_components/ha_behringer_mixer/config_flow.py
@@ -64,7 +64,7 @@ class BehringerMixerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     def create_list(max_number):
-        """ Create a list of numbers """
+        """Create a list of numbers."""
         return list(range(1, max_number + 1))
 
     async def async_step_name(

--- a/custom_components/ha_behringer_mixer/config_flow.py
+++ b/custom_components/ha_behringer_mixer/config_flow.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.helpers import selector
+from homeassistant.helpers import config_validation as cv
 
 from .api import (
     BehringerMixerApiClient,
@@ -61,18 +62,39 @@ class BehringerMixerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors=_errors,
         )
 
+    @staticmethod
+    def create_list(max_number):
+        return [item for item in range(1, max_number + 1)]
+
     async def async_step_name(
         self,
         user_input: dict | None = None,
     ) -> config_entries.FlowResult:
         """Handle a flow initialized by the user."""
+
         _errors = {}
         if user_input is not None and user_input.get("NAME"):
             self.init_info["NAME"] = user_input["NAME"]
+            self.init_info["CHANNEL_CONFIG"] = user_input["CHANNELS"]
+            self.init_info["BUS_CONFIG"] = user_input["BUSSES"]
+            self.init_info["DCA_CONFIG"] = user_input["DCAS"]
+            self.init_info["MATRIX_CONFIG"] = user_input["MATRICES"]
+            self.init_info["AUXIN_CONFIG"] = user_input["AUXINS"]
+            self.init_info["MAIN_CONFIG"] = user_input["MAIN"] or False
             return self.async_create_entry(
                 title=self.init_info["NAME"],
                 data=self.init_info,
             )
+
+        mixer_info = await self._mixer_info(
+            mixer_ip=user_input["MIXER_IP"],
+            mixer_type=user_input["MIXER_TYPE"],
+        )
+        channel_options = self.create_list(mixer_info["channel"]["number"])
+        bus_options = self.create_list(mixer_info["bus"]["number"])
+        matrix_options = self.create_list(mixer_info["matrix"]["number"])
+        dca_options = self.create_list(mixer_info["dca"]["number"])
+        auxin_options = self.create_list(mixer_info["auxin"]["number"])
 
         return self.async_show_form(
             step_id="name",
@@ -85,15 +107,39 @@ class BehringerMixerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                             type=selector.TextSelectorType.TEXT
                         ),
                     ),
+                    vol.Optional("CHANNELS", default=channel_options): cv.multi_select(
+                        channel_options
+                    ),
+                    vol.Optional("BUSSES", default=bus_options): cv.multi_select(
+                        bus_options
+                    ),
+                    vol.Optional("DCAS", default=dca_options): cv.multi_select(
+                        dca_options
+                    ),
+                    vol.Optional("MATRICES", default=matrix_options): cv.multi_select(
+                        matrix_options
+                    ),
+                    vol.Optional("AUXINS", default=auxin_options): cv.multi_select(
+                        auxin_options
+                    ),
+                    vol.Optional("MAIN", default=True): cv.boolean,
                 }
             ),
             errors=_errors,
         )
 
     async def _test_connect(self, mixer_ip: str, mixer_type: str) -> None:
-        """Validate credentials."""
+        """Validate IP/Type."""
         client = BehringerMixerApiClient(mixer_ip=mixer_ip, mixer_type=mixer_type)
         await client.setup(setup_callbacks=False)
         await client.async_get_data()
         await client.stop()
         return client.mixer_network_name()
+
+    async def _mixer_info(self, mixer_ip: str, mixer_type: str) -> None:
+        """Load Mixer Information."""
+        client = BehringerMixerApiClient(mixer_ip=mixer_ip, mixer_type=mixer_type)
+        await client.setup(setup_callbacks=False)
+        await client.async_get_data()
+        await client.stop()
+        return client.mixer_info()

--- a/custom_components/ha_behringer_mixer/coordinator.py
+++ b/custom_components/ha_behringer_mixer/coordinator.py
@@ -58,11 +58,39 @@ class MixerDataUpdateCoordinator(DataUpdateCoordinator):
         }
         if self.config_entry.data.get("MAIN_CONFIG"):
             self.fader_group(entities, "main", 0, "main/st")
+        # Input channels
         for entity_type in types:
             # num_type = mixer_info.get(entity_type, {}).get("number")
             base_key = mixer_info.get(entity_type, {}).get("base_address")
             for index_number in self.config_entry.data[entity_type.upper() + "_CONFIG"]:
                 self.fader_group(entities, entity_type, index_number, base_key)
+        # Channel to bus sends
+        if self.config_entry.data.get("CHANNELSENDS_CONFIG"):
+            base_key = mixer_info.get("channel_sends", {}).get("base_address")
+            for channel_number in self.config_entry.data["CHANNEL_CONFIG"]:
+                for bus_number in self.config_entry.data["BUS_CONFIG"]:
+                    self.fader_group(
+                        entities,
+                        "chsend",
+                        f"{channel_number}/{bus_number}",
+                        base_key,
+                        f"channel {channel_number} -> bus {bus_number}",
+                    )
+
+        # Bus to matrix sends
+        num_matrix = mixer_info.get("matrix", {}).get("number")
+        if num_matrix and self.config_entry.data.get("BUSSENDS_CONFIG"):
+            base_key = mixer_info.get("bus_sends", {}).get("base_address")
+            for bus_number in self.config_entry.data["BUS_CONFIG"]:
+                for matrix_number in self.config_entry.data["MATRIX_CONFIG"]:
+                    self.fader_group(
+                        entities,
+                        "bussend",
+                        f"{bus_number}/{matrix_number}",
+                        base_key,
+                        f"bus {bus_number} -> matrix {matrix_number}",
+                    )
+
         entities["NUMBER"].append(
             {
                 "type": "scene",
@@ -81,7 +109,7 @@ class MixerDataUpdateCoordinator(DataUpdateCoordinator):
         )
         return entities
 
-    def fader_group(self, entities, entity_type, index_number, base_key):
+    def fader_group(self, entities, entity_type, index_number, base_key, name=""):
         """Generate entities for a fader."""
         entity_part = entity_type
         base_address = f"/{base_key}"
@@ -90,6 +118,7 @@ class MixerDataUpdateCoordinator(DataUpdateCoordinator):
             entity_part = entity_type + "_" + str(index_number)
             base_address = base_address + "/" + str(index_number)
             default_name = default_name + " " + str(index_number or 0)
+        default_name = name or default_name
         entities["SWITCH"].append(
             {
                 "type": "on",

--- a/custom_components/ha_behringer_mixer/coordinator.py
+++ b/custom_components/ha_behringer_mixer/coordinator.py
@@ -56,11 +56,12 @@ class MixerDataUpdateCoordinator(DataUpdateCoordinator):
             "NUMBER": [],
             "SWITCH": [],
         }
-        self.fader_group(entities, "main", 0, "main/st")
+        if self.config_entry.data.get("MAIN_CONFIG"):
+            self.fader_group(entities, "main", 0, "main/st")
         for entity_type in types:
-            num_type = mixer_info.get(entity_type, {}).get("number")
+            # num_type = mixer_info.get(entity_type, {}).get("number")
             base_key = mixer_info.get(entity_type, {}).get("base_address")
-            for index_number in range(1, num_type + 1):
+            for index_number in self.config_entry.data[entity_type.upper() + "_CONFIG"]:
                 self.fader_group(entities, entity_type, index_number, base_key)
         entities["NUMBER"].append(
             {

--- a/custom_components/ha_behringer_mixer/manifest.json
+++ b/custom_components/ha_behringer_mixer/manifest.json
@@ -8,7 +8,7 @@
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/wrodie/ha_behringer_mixer/issues",
     "requirements": [
-      "behringer-mixer==0.4.1"
+      "behringer-mixer==0.4.2"
     ],
-    "version": "0.1.1"
+    "version": "0.1.2"
 }

--- a/custom_components/ha_behringer_mixer/translations/en.json
+++ b/custom_components/ha_behringer_mixer/translations/en.json
@@ -11,7 +11,13 @@
             "name": {
                 "description": "What do you want to call this mixer?",
                 "data": {
-                    "NAME": "Mixer Name"
+                    "NAME": "Mixer Name",
+                    "CHANNELS": "Channels to import",
+                    "BUSSES": "Busses to import",
+                    "MATRICES": "Matrices to import",
+                    "AUXINS": "Aux ins to import",
+                    "DCAS": "DCAs to import",
+                    "MAIN": "Do you want to import the Main/LR Fader?"
                 }
             }
         },

--- a/custom_components/ha_behringer_mixer/translations/en.json
+++ b/custom_components/ha_behringer_mixer/translations/en.json
@@ -17,7 +17,9 @@
                     "MATRICES": "Matrices to import",
                     "AUXINS": "Aux ins to import",
                     "DCAS": "DCAs to import",
-                    "MAIN": "Do you want to import the Main/LR Fader?"
+                    "MAIN": "Do you want to import the Main/LR Fader?",
+                    "CHANNELSENDS": "Do you want to import Channel->Bus Sends?",
+                    "BUSSENDS": "Do you want to import Bus->Matrix Sends?"
                 }
             }
         },


### PR DESCRIPTION
New Features:
 - Allow the user to select which channels/busses/matrices etc are
   actually imported/created, as there can be a lot of entities if
everything imported- can only be done on initial setup
 - Support the control of the Channel->Bus send faders
 - Support the control of the Bus->Matrix send faders

Bug Fixing
 - Detect the entering of the wrong IP address on setup