### PR TITLE
feat: add more configuration

### DIFF
--- a/custom_components/ha_behringer_mixer/__init__.py
+++ b/custom_components/ha_behringer_mixer/__init__.py
@@ -87,6 +87,13 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
         new["BUSSENDS_CONFIG"] = False
         config_entry.version = 2
         hass.config_entries.async_update_entry(config_entry, data=new)
+    if config_entry.version < 3:
+        new = {**config_entry.data}
+        new["DBSENSORS"] = True
+        new["UPSCALE_100"] = False
+        config_entry.version = 3
+        hass.config_entries.async_update_entry(config_entry, data=new)
+
     LOGGER.debug("Migration to version %s successful", config_entry.version)
 
     return True

--- a/custom_components/ha_behringer_mixer/config_flow.py
+++ b/custom_components/ha_behringer_mixer/config_flow.py
@@ -18,7 +18,7 @@ from .const import DOMAIN, LOGGER
 class BehringerMixerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow for BehringerMixer."""
 
-    VERSION = 2
+    VERSION = 3
 
     async def async_step_user(
         self,
@@ -84,6 +84,8 @@ class BehringerMixerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             self.init_info["MAIN_CONFIG"] = user_input["MAIN"] or False
             self.init_info["CHANNELSENDS_CONFIG"] = user_input["CHANNELSENDS"] or False
             self.init_info["BUSSENDS_CONFIG"] = user_input["BUSSENDS"] or False
+            self.init_info["DBSENSORS"] = user_input["DBSENSORS"] or False
+            self.init_info["UPSCALE_100"] = user_input["UPSCALE_100"] or False
             return self.async_create_entry(
                 title=self.init_info["NAME"],
                 data=self.init_info,
@@ -128,6 +130,8 @@ class BehringerMixerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Optional("MAIN", default=True): cv.boolean,
                     vol.Optional("CHANNELSENDS", default=False): cv.boolean,
                     vol.Optional("BUSSENDS", default=False): cv.boolean,
+                    vol.Optional("DBSENSORS", default=True): cv.boolean,
+                    vol.Optional("UPSCALE_100", default=False): cv.boolean,
                 }
             ),
             errors=_errors,

--- a/custom_components/ha_behringer_mixer/coordinator.py
+++ b/custom_components/ha_behringer_mixer/coordinator.py
@@ -155,12 +155,13 @@ class MixerDataUpdateCoordinator(DataUpdateCoordinator):
                 "base_address": base_address,
             }
         )
-        entities["SENSOR"].append(
-            {
-                "type": "faderdb",
-                "key": f"{self.entity_base_id}_{entity_part}_fader_db",
-                "default_name": default_name,
-                "name_suffix": "Fader (dB)",
-                "base_address": base_address,
-            }
-        )
+        if self.config_entry.data.get("DBSENSORS"):
+            entities["SENSOR"].append(
+                {
+                    "type": "faderdb",
+                    "key": f"{self.entity_base_id}_{entity_part}_fader_db",
+                    "default_name": default_name,
+                    "name_suffix": "Fader (dB)",
+                    "base_address": base_address,
+                }
+            )

--- a/custom_components/ha_behringer_mixer/number.py
+++ b/custom_components/ha_behringer_mixer/number.py
@@ -98,6 +98,7 @@ class BehringerMixerFader(BehringerMixerEntity, NumberEntity):
 
     @property
     def extra_state_attributes(self):
+        """ Generate extra state attributes"""
         attrs = {}
         attrs["db"] = self.coordinator.data.get(self.base_address + "/mix_fader_db", "") or -90
         return attrs

--- a/custom_components/ha_behringer_mixer/number.py
+++ b/custom_components/ha_behringer_mixer/number.py
@@ -98,7 +98,7 @@ class BehringerMixerFader(BehringerMixerEntity, NumberEntity):
 
     @property
     def extra_state_attributes(self):
-        """ Generate extra state attributes"""
+        """Generate extra state attributes."""
         attrs = {}
         attrs["db"] = self.coordinator.data.get(self.base_address + "/mix_fader_db", "") or -90
         return attrs

--- a/custom_components/ha_behringer_mixer/number.py
+++ b/custom_components/ha_behringer_mixer/number.py
@@ -69,18 +69,35 @@ class BehringerMixerSceneNumber(BehringerMixerEntity, NumberEntity):
 class BehringerMixerFader(BehringerMixerEntity, NumberEntity):
     """Behringer_mixer Number class."""
 
-    _attr_native_max_value = 1
     _attr_native_min_value = 0
     _attr_icon = "mdi:volume-source"
 
     @property
+    def native_max_value(self) -> float | None:
+        """Maximum value of the entity."""
+        if self.coordinator.config_entry.data.get("UPSCALE_100"):
+            return 100
+        return 1
+
+    @property
     def native_value(self) -> float | None:
         """Value of the entity."""
-        return self.coordinator.data.get(self.base_address + "/mix_fader", "")
+        value = self.coordinator.data.get(self.base_address + "/mix_fader", "")
+        if self.coordinator.config_entry.data.get("UPSCALE_100"):
+            return 100 * value
+        return value
 
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
 
+        if self.coordinator.config_entry.data.get("UPSCALE_100"):
+            value = value / 100
         await self.coordinator.client.async_set_value(
             self.base_address + "/mix_fader", value
         )
+
+    @property
+    def extra_state_attributes(self):
+        attrs = {}
+        attrs["db"] = self.coordinator.data.get(self.base_address + "/mix_fader_db", "") or -90
+        return attrs

--- a/custom_components/ha_behringer_mixer/translations/en.json
+++ b/custom_components/ha_behringer_mixer/translations/en.json
@@ -19,7 +19,9 @@
                     "DCAS": "DCAs to import",
                     "MAIN": "Import the Main/LR Fader?",
                     "CHANNELSENDS": "Import Channel->Bus Sends?",
-                    "BUSSENDS": "Import Bus->Matrix Sends?"
+                    "BUSSENDS": "Import Bus->Matrix Sends?",
+                    "DBSENSORS": "Create additional sensors with the dB values of the faders.  This value is also available as an attribute on the fader.",
+                    "UPSCALE_100": "Convert fader base values from 0.0-1.0 to 0-100 (do this only if you really need it)"
                 }
             }
         },


### PR DESCRIPTION
- db values are now available as attributes on the fader
- new configuration option that allows you to not create the DB sensors
- new configuration option that changes the scaling of the values from 0-1 to 1-100.  This allows the mixer to be used with other plugins that expect percentage based values
- changed the text of some messages