### PR TITLE
Head amps

### DIFF
--- a/custom_components/ha_behringer_mixer/__init__.py
+++ b/custom_components/ha_behringer_mixer/__init__.py
@@ -85,14 +85,16 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
         new["MAIN_CONFIG"] = True
         new["CHANNELSENDS_CONFIG"] = False
         new["BUSSENDS_CONFIG"] = False
-        config_entry.version = 2
-        hass.config_entries.async_update_entry(config_entry, data=new)
+        hass.config_entries.async_update_entry(config_entry, data=new, version =2)
     if config_entry.version < 3:
         new = {**config_entry.data}
         new["DBSENSORS"] = True
         new["UPSCALE_100"] = False
-        config_entry.version = 3
-        hass.config_entries.async_update_entry(config_entry, data=new)
+        hass.config_entries.async_update_entry(config_entry, data=new, version =3)
+    if config_entry.version < 4:
+        new = {**config_entry.data}
+        new["HEADAMPS_CONFIG"] = 0
+        hass.config_entries.async_update_entry(config_entry, data=new, version =4)
 
     LOGGER.debug("Migration to version %s successful", config_entry.version)
 

--- a/custom_components/ha_behringer_mixer/config_flow.py
+++ b/custom_components/ha_behringer_mixer/config_flow.py
@@ -18,7 +18,7 @@ from .const import DOMAIN, LOGGER
 class BehringerMixerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow for BehringerMixer."""
 
-    VERSION = 3
+    VERSION = 4
 
     async def async_step_user(
         self,
@@ -86,6 +86,7 @@ class BehringerMixerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             self.init_info["BUSSENDS_CONFIG"] = user_input["BUSSENDS"] or False
             self.init_info["DBSENSORS"] = user_input["DBSENSORS"] or False
             self.init_info["UPSCALE_100"] = user_input["UPSCALE_100"] or False
+            self.init_info["HEADAMPS_CONFIG"] = user_input["HEADAMPS"]
             return self.async_create_entry(
                 title=self.init_info["NAME"],
                 data=self.init_info,
@@ -100,6 +101,7 @@ class BehringerMixerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         matrix_options = self.create_list(mixer_info["matrix"]["number"])
         dca_options = self.create_list(mixer_info["dca"]["number"])
         auxin_options = self.create_list(mixer_info["auxin"]["number"])
+        headamps_options = self.create_list(mixer_info["head_amps"]["number"])
 
         return self.async_show_form(
             step_id="name",
@@ -126,6 +128,9 @@ class BehringerMixerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     ),
                     vol.Optional("AUXINS", default=auxin_options): cv.multi_select(
                         auxin_options
+                    ),
+                    vol.Optional("HEADAMPS", default=[]): cv.multi_select(
+                        headamps_options
                     ),
                     vol.Optional("MAIN", default=True): cv.boolean,
                     vol.Optional("CHANNELSENDS", default=False): cv.boolean,

--- a/custom_components/ha_behringer_mixer/coordinator.py
+++ b/custom_components/ha_behringer_mixer/coordinator.py
@@ -199,7 +199,7 @@ class MixerDataUpdateCoordinator(DataUpdateCoordinator):
         )
         entities["NUMBER"].append(
             {
-                "type": "float",
+                "type": "headamp_gain",
                 "key": f"{self.entity_base_id}_{entity_part}_gain",
                 "default_name": default_name,
                 "name_suffix": "Gain",

--- a/custom_components/ha_behringer_mixer/coordinator.py
+++ b/custom_components/ha_behringer_mixer/coordinator.py
@@ -94,6 +94,16 @@ class MixerDataUpdateCoordinator(DataUpdateCoordinator):
                         base_key,
                         f"bus {bus_number} -> matrix {matrix_number}",
                     )
+        # Head Amps
+        if self.config_entry.data.get("HEADAMPS_CONFIG"):
+            base_key = mixer_info.get("head_amps", {}).get("base_address")
+            for headamp_number in self.config_entry.data.get("HEADAMPS_CONFIG", []):
+                self.headamp_group(
+                    entities,
+                    "headamp",
+                    headamp_number,
+                    base_key
+                )
 
         entities["NUMBER"].append(
             {
@@ -141,7 +151,7 @@ class MixerDataUpdateCoordinator(DataUpdateCoordinator):
         default_name = name or default_name
         entities["SWITCH"].append(
             {
-                "type": "on",
+                "type": "mute",
                 "key": f"{self.entity_base_id}_{entity_part}_on",
                 "default_name": default_name,
                 "name_suffix": "On",
@@ -167,3 +177,32 @@ class MixerDataUpdateCoordinator(DataUpdateCoordinator):
                     "base_address": base_address,
                 }
             )
+
+    def headamp_group(self, entities, entity_type, index_number, base_key, name=""):
+        """Generate entities for a headamp."""
+        entity_part = entity_type
+        base_address = f"/{base_key}"
+        default_name = "HeadAmp"
+        if index_number:
+            entity_part = entity_type + "_" + str(index_number)
+            base_address = base_address + "/" + str(index_number)
+            default_name = default_name + " " + str(index_number or 0)
+        default_name = name or default_name
+        entities["SWITCH"].append(
+            {
+                "type": "on",
+                "key": f"{self.entity_base_id}_{entity_part}_phantom",
+                "default_name": default_name,
+                "name_suffix": "Phantom Power",
+                "base_address": f"{base_address}/phantom",
+            }
+        )
+        entities["NUMBER"].append(
+            {
+                "type": "float",
+                "key": f"{self.entity_base_id}_{entity_part}_gain",
+                "default_name": default_name,
+                "name_suffix": "Gain",
+                "base_address": f"{base_address}/gain",
+            }
+        )

--- a/custom_components/ha_behringer_mixer/manifest.json
+++ b/custom_components/ha_behringer_mixer/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/wrodie/ha_behringer_mixer/issues",
   "requirements": [
-    "behringer-mixer==0.4.6"
+    "behringer-mixer==0.4.7"
   ],
-  "version": "0.1.11"
+  "version": "0.1.12"
 }

--- a/custom_components/ha_behringer_mixer/number.py
+++ b/custom_components/ha_behringer_mixer/number.py
@@ -32,9 +32,9 @@ def build_entities(coordinator):
                     entity_setup=entity,
                 )
             )
-        elif entity.get("type") == "float":
+        elif entity.get("type") == "headamp_gain":
             entities.append(
-                BehringerMixerFloat(
+                BehringerMixerHeadAmpGain(
                     coordinator=coordinator,
                     entity_description=NumberEntityDescription(
                         key=entity.get("key"),
@@ -76,7 +76,7 @@ class BehringerMixerSceneNumber(BehringerMixerEntity, NumberEntity):
         """Update the current scene."""
         await self.coordinator.client.load_scene(int(value))
 
-class BehringerMixerFloat(BehringerMixerEntity, NumberEntity):
+class BehringerMixerHeadAmpGain(BehringerMixerEntity, NumberEntity):
     """Behringer_mixer Float Number class."""
 
     _attr_native_min_value = 0
@@ -96,6 +96,12 @@ class BehringerMixerFloat(BehringerMixerEntity, NumberEntity):
         await self.coordinator.client.async_set_value(
             self.base_address, value
         )
+    @property
+    def extra_state_attributes(self):
+        """Generate extra state attributes."""
+        attrs = {}
+        attrs["db"] = self.coordinator.data.get(self.base_address + "_db", "") or -12
+        return attrs
 
 class BehringerMixerFader(BehringerMixerEntity, NumberEntity):
     """Behringer_mixer Number class."""

--- a/custom_components/ha_behringer_mixer/number.py
+++ b/custom_components/ha_behringer_mixer/number.py
@@ -32,6 +32,17 @@ def build_entities(coordinator):
                     entity_setup=entity,
                 )
             )
+        elif entity.get("type") == "float":
+            entities.append(
+                BehringerMixerFloat(
+                    coordinator=coordinator,
+                    entity_description=NumberEntityDescription(
+                        key=entity.get("key"),
+                        name=entity.get("default_name"),
+                    ),
+                    entity_setup=entity,
+                )
+            )
         else:
             entities.append(
                 BehringerMixerFader(
@@ -65,6 +76,26 @@ class BehringerMixerSceneNumber(BehringerMixerEntity, NumberEntity):
         """Update the current scene."""
         await self.coordinator.client.load_scene(int(value))
 
+class BehringerMixerFloat(BehringerMixerEntity, NumberEntity):
+    """Behringer_mixer Float Number class."""
+
+    _attr_native_min_value = 0
+    _attr_native_max_value = 1
+    @property
+    def native_value(self) -> float | None:
+        """Value of the entity."""
+        return self.coordinator.data.get(self.base_address, "")
+
+    @property
+    def name(self) -> str | None:
+        """Name  of the entity."""
+        return self.default_name
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Update the current scene."""
+        await self.coordinator.client.async_set_value(
+            self.base_address, value
+        )
 
 class BehringerMixerFader(BehringerMixerEntity, NumberEntity):
     """Behringer_mixer Number class."""

--- a/custom_components/ha_behringer_mixer/switch.py
+++ b/custom_components/ha_behringer_mixer/switch.py
@@ -18,18 +18,51 @@ def build_entities(coordinator):
     """Build up the entities."""
     entities = []
     for entity in coordinator.entity_catalog.get("SWITCH"):
-        entities.append(
-            BehringerMixerSwitch(
-                coordinator=coordinator,
-                entity_description=SwitchEntityDescription(
-                    key=entity.get("key"),
-                    name=entity.get("default_name"),
-                ),
-                entity_setup=entity,
+
+        if entity.get("type") == "mute":
+            entities.append(
+                BehringerMixerSwitch(
+                    coordinator=coordinator,
+                    entity_description=SwitchEntityDescription(
+                        key=entity.get("key"),
+                        name=entity.get("default_name"),
+                    ),
+                    entity_setup=entity,
+                )
             )
-        )
+        else:
+            entities.append(
+                BehringerMixerSwitchGeneric(
+                    coordinator=coordinator,
+                    entity_description=SwitchEntityDescription(
+                        key=entity.get("key"),
+                        name=entity.get("default_name"),
+                    ),
+                    entity_setup=entity,
+                )
+            )
     return entities
 
+class BehringerMixerSwitchGeneric(BehringerMixerEntity, SwitchEntity):
+    """Behringer_mixer switch generic class."""
+
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if the switch is on."""
+        return self.coordinator.data.get(self.base_address, False)
+
+    async def async_turn_on(self, **_: any) -> None:
+        """Turn on the switch."""
+        await self.coordinator.client.async_set_value(
+            self.base_address, True
+        )
+
+    async def async_turn_off(self, **_: any) -> None:
+        """Turn off the switch."""
+        await self.coordinator.client.async_set_value(
+            self.base_address, False
+        )
 
 class BehringerMixerSwitch(BehringerMixerEntity, SwitchEntity):
     """Behringer_mixer switch class."""

--- a/custom_components/ha_behringer_mixer/switch.py
+++ b/custom_components/ha_behringer_mixer/switch.py
@@ -46,7 +46,6 @@ def build_entities(coordinator):
 class BehringerMixerSwitchGeneric(BehringerMixerEntity, SwitchEntity):
     """Behringer_mixer switch generic class."""
 
-
     @property
     def is_on(self) -> bool:
         """Return true if the switch is on."""

--- a/custom_components/ha_behringer_mixer/translations/en.json
+++ b/custom_components/ha_behringer_mixer/translations/en.json
@@ -22,7 +22,7 @@
                     "BUSSENDS": "Import Bus->Matrix Sends?",
                     "DBSENSORS": "Create additional sensors with the dB values of the faders.  This value is also available as an attribute on the fader.",
                     "UPSCALE_100": "Convert fader base values from 0.0-1.0 to 0-100 (do this only if you really need it)",
-                    "HEADAMPS": "Head Amps to import?"
+                    "HEADAMPS": "Head Amps to import"
                 }
             }
         },

--- a/custom_components/ha_behringer_mixer/translations/en.json
+++ b/custom_components/ha_behringer_mixer/translations/en.json
@@ -21,7 +21,8 @@
                     "CHANNELSENDS": "Import Channel->Bus Sends?",
                     "BUSSENDS": "Import Bus->Matrix Sends?",
                     "DBSENSORS": "Create additional sensors with the dB values of the faders.  This value is also available as an attribute on the fader.",
-                    "UPSCALE_100": "Convert fader base values from 0.0-1.0 to 0-100 (do this only if you really need it)"
+                    "UPSCALE_100": "Convert fader base values from 0.0-1.0 to 0-100 (do this only if you really need it)",
+                    "HEADAMPS": "Head Amps to import?"
                 }
             }
         },
@@ -31,5 +32,4 @@
             "unknown": "Unknown error occurred."
         }
     }
-
 }


### PR DESCRIPTION
Add support for read/write:
 - Head amps - Gain
 - Head amps - Phantom Power

As part of the configuration you choose what head amps you want to import - with X32 this can be up to 128 (multiple stage boxes)
Note. Head amps are separate from channels.