### PR TITLE
feat: add option to import faders as media players

### DIFF
--- a/custom_components/ha_behringer_mixer/__init__.py
+++ b/custom_components/ha_behringer_mixer/__init__.py
@@ -14,6 +14,7 @@ PLATFORMS: list[Platform] = [
     Platform.NUMBER,
     Platform.SENSOR,
     Platform.SELECT,
+    Platform.MEDIA_PLAYER,
 ]
 
 

--- a/custom_components/ha_behringer_mixer/config_flow.py
+++ b/custom_components/ha_behringer_mixer/config_flow.py
@@ -84,6 +84,7 @@ class BehringerMixerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             self.init_info["MAIN_CONFIG"] = user_input["MAIN"] or False
             self.init_info["CHANNELSENDS_CONFIG"] = user_input["CHANNELSENDS"] or False
             self.init_info["BUSSENDS_CONFIG"] = user_input["BUSSENDS"] or False
+            self.init_info["FADER_MEDIA_PLAYERS"] = user_input["FADER_MEDIA_PLAYERS"] or False
             self.init_info["DBSENSORS"] = user_input["DBSENSORS"] or False
             self.init_info["UPSCALE_100"] = user_input["UPSCALE_100"] or False
             self.init_info["HEADAMPS_CONFIG"] = user_input["HEADAMPS"]
@@ -137,6 +138,7 @@ class BehringerMixerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Optional("BUSSENDS", default=False): cv.boolean,
                     vol.Optional("DBSENSORS", default=True): cv.boolean,
                     vol.Optional("UPSCALE_100", default=False): cv.boolean,
+                    vol.Optional("FADER_MEDIA_PLAYERS", default=False): cv.boolean,
                 }
             ),
             errors=_errors,

--- a/custom_components/ha_behringer_mixer/coordinator.py
+++ b/custom_components/ha_behringer_mixer/coordinator.py
@@ -56,6 +56,7 @@ class MixerDataUpdateCoordinator(DataUpdateCoordinator):
             "NUMBER": [],
             "SWITCH": [],
             "SELECT": [],
+            "MEDIA_PLAYER": [],
         }
         if self.config_entry.data.get("MAIN_CONFIG"):
             self.fader_group(entities, "main", 0, "main/st")
@@ -149,24 +150,37 @@ class MixerDataUpdateCoordinator(DataUpdateCoordinator):
             base_address = base_address + "/" + str(index_number)
             default_name = default_name + " " + str(index_number or 0)
         default_name = name or default_name
-        entities["SWITCH"].append(
-            {
-                "type": "mute",
-                "key": f"{self.entity_base_id}_{entity_part}_on",
-                "default_name": default_name,
-                "name_suffix": "On",
-                "base_address": base_address,
-            }
-        )
-        entities["NUMBER"].append(
-            {
-                "type": "fader",
-                "key": f"{self.entity_base_id}_{entity_part}_fader",
-                "default_name": default_name,
-                "name_suffix": "Fader",
-                "base_address": base_address,
-            }
-        )
+
+        if self.config_entry.data.get("FADER_MEDIA_PLAYERS"):
+            entities["MEDIA_PLAYER"].append(
+                {
+                    "type": "fader",
+                    "key": f"{self.entity_base_id}_{entity_part}_player",
+                    "default_name": default_name,
+                    "name_suffix": "Fader",
+                    "base_address": base_address,
+                }
+            )
+        else:
+            entities["SWITCH"].append(
+                {
+                    "type": "mute",
+                    "key": f"{self.entity_base_id}_{entity_part}_on",
+                    "default_name": default_name,
+                    "name_suffix": "On",
+                    "base_address": base_address,
+                }
+            )
+            entities["NUMBER"].append(
+                {
+                    "type": "fader",
+                    "key": f"{self.entity_base_id}_{entity_part}_fader",
+                    "default_name": default_name,
+                    "name_suffix": "Fader",
+                    "base_address": base_address,
+                }
+            )
+
         if self.config_entry.data.get("DBSENSORS"):
             entities["SENSOR"].append(
                 {

--- a/custom_components/ha_behringer_mixer/media_player.py
+++ b/custom_components/ha_behringer_mixer/media_player.py
@@ -1,0 +1,106 @@
+"""Media player platform for behringer_mixer."""
+
+from __future__ import annotations
+
+from homeassistant.components.media_player import (
+    MediaPlayerEntity,
+    MediaPlayerEntityDescription,
+    MediaPlayerDeviceClass,
+)
+from homeassistant.components.media_player.const import (
+    MediaType,
+    MediaPlayerEntityFeature,
+)
+from homeassistant.const import (
+    STATE_OK,
+)
+
+# from homeassistant.helpers import config_validation as cv, entity_platform
+# import voluptuous as vol
+
+from .const import DOMAIN
+from .entity import BehringerMixerEntity
+
+
+async def async_setup_entry(hass, entry, async_add_devices):
+    """Set up the sensor platform."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    devices_list = build_entities(coordinator)
+    async_add_devices(devices_list)
+
+
+def build_entities(coordinator):
+    """Build up the entities."""
+    entities = []
+    for entity in coordinator.entity_catalog.get("MEDIA_PLAYER"):
+        entities.append(
+            BehringerMixerFaderMediaPlayer(
+                coordinator=coordinator,
+                entity_description=MediaPlayerEntityDescription(
+                    key=entity.get("key"),
+                    name=entity.get("default_name"),
+                ),
+                entity_setup=entity,
+            )
+        )
+    return entities
+
+
+class BehringerMixerFaderMediaPlayer(BehringerMixerEntity, MediaPlayerEntity):
+    """Behringer_mixer Fader Media Player class."""
+
+    _attr_native_min_value = 0
+    _attr_icon = "mdi:speaker"
+
+    @property
+    def device_class(self) -> MediaPlayerDeviceClass | None:
+        """Return the device class of the media player."""
+        return MediaPlayerDeviceClass.SPEAKER
+
+    @property
+    def supported_features(self) -> MediaPlayerEntityFeature:
+        """Flag media player features that are supported."""
+        return (
+            MediaPlayerEntityFeature.VOLUME_SET | MediaPlayerEntityFeature.VOLUME_MUTE
+        )
+
+    @property
+    def media_content_type(self):
+        """Content type of current playing media."""
+        return MediaType.MUSIC
+
+    @property
+    def volume_level(self):
+        """Volume level of the media player (0..1)."""
+        return self.coordinator.data.get(self.base_address + "/mix_fader", "")
+
+    @property
+    def is_volume_muted(self):
+        """Boolean if volume is currently muted."""
+        return not self.coordinator.data.get(self.base_address + "/mix_on", False)
+
+    async def async_set_volume_level(self, volume):
+        """Set volume level."""
+        await self.coordinator.client.async_set_value(
+            self.base_address + "/mix_fader", volume
+        )
+
+    async def async_mute_volume(self, mute):
+        """Mute."""
+        await self.coordinator.client.async_set_value(
+            self.base_address + "/mix_on", not mute
+        )
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return STATE_OK
+
+    @property
+    def extra_state_attributes(self):
+        """Generate extra state attributes."""
+        attrs = {}
+        attrs["db"] = (
+            self.coordinator.data.get(self.base_address + "/mix_fader_db", "") or -90
+        )
+        return attrs

--- a/custom_components/ha_behringer_mixer/number.py
+++ b/custom_components/ha_behringer_mixer/number.py
@@ -39,6 +39,7 @@ def build_entities(coordinator):
                     entity_description=NumberEntityDescription(
                         key=entity.get("key"),
                         name=entity.get("default_name"),
+                        native_step=0.01,
                     ),
                     entity_setup=entity,
                 )
@@ -50,6 +51,7 @@ def build_entities(coordinator):
                     entity_description=NumberEntityDescription(
                         key=entity.get("key"),
                         name=entity.get("default_name"),
+                        native_step=0.01,
                     ),
                     entity_setup=entity,
                 )

--- a/custom_components/ha_behringer_mixer/translations/en.json
+++ b/custom_components/ha_behringer_mixer/translations/en.json
@@ -20,6 +20,7 @@
                     "MAIN": "Import the Main/LR Fader?",
                     "CHANNELSENDS": "Import Channel->Bus Sends?",
                     "BUSSENDS": "Import Bus->Matrix Sends?",
+                    "FADER_MEDIA_PLAYERS": "Import Faders as Media Players?",
                     "DBSENSORS": "Create additional sensors with the dB values of the faders.  This value is also available as an attribute on the fader.",
                     "UPSCALE_100": "Convert fader base values from 0.0-1.0 to 0-100 (do this only if you really need it)",
                     "HEADAMPS": "Head Amps to import"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colorlog==6.9.0
-homeassistant==2023.11.2
+homeassistant==2025.1.0
 
 pip>=21.0,<24.4
 ruff==0.8.4


### PR DESCRIPTION
Thanks for this project, I have been wondering about making something like this myself but don't know python (or home assistant integrations) well enough to know where to begin. For a few years I have been using a custom tool which bridged the x32 to mqtt and a muddled together way of exposing that as a media-player entity, but it needed some fixing with newer ha then I stumbled upon your project.

One thing I much prefer is having each fader and mute state being exposed as a media-player entity instead of as a number and a switch. This gives it a nicer presentation in the default ha dashboards. 

So this PR adds an option during configuration which will set it up to produce a single media_player entity instead of a number and switch for each fader.

![image](https://github.com/user-attachments/assets/c58618a9-919a-4f23-8def-38d1bda63ccd)
![image](https://github.com/user-attachments/assets/29901e1c-dcec-4feb-b135-a5cde65ec1d3)
